### PR TITLE
Optimalize eagle text generation techniques

### DIFF
--- a/eagle.py
+++ b/eagle.py
@@ -17,6 +17,7 @@ PROMPTS = [
 Input: {text}
 
 Response:""",
+"{text}\n"
 #"""User: hi
 #
 #Assistant: Hi. I am your assistant and I will provide expert full response in full details. Please feel free to ask any question and I will always answer it.

--- a/eagle.py
+++ b/eagle.py
@@ -9,6 +9,42 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from misc import LANGUAGE_CODE_MAP, MODEL_GENERATE_ARGS, generate_chat_prompt, get_logger
 
+PROMPTS = [
+    #"Your goal is to paraphrase text in {language} using different words and sentence composition. Respond with only paraphrased text and nothing else. Text to paraphrase: {text}",
+    #"Your goal is to paraphrase text in {language} using different words and sentence composition. Respond with only paraphrased text and nothing else. Text to paraphrase: {text}\nParaphrased text:",
+    """Instruction: Your goal is to paraphrase text in {language} using different words and sentence composition. Respond only in {language} language. Respond only with the paraphrased text and nothing else.
+
+Input: {text}
+
+Response:""",
+#"""User: hi
+#
+#Assistant: Hi. I am your assistant and I will provide expert full response in full details. Please feel free to ask any question and I will always answer it.
+#
+#User: Your goal is to paraphrase text in {language} using different words and sentence composition. Respond with only paraphrased text and nothing else. Text to paraphrase: {text}
+#
+#Assistant:""",
+#"""User: hi
+#
+#Assistant: Hi. I am your assistant and I will provide expert full response in full details. Please feel free to ask any question and I will always answer it.
+#
+#User: Your goal is to paraphrase text in {language} using different words and sentence composition. Respond with only paraphrased text and nothing else. Text to paraphrase: "{text}"
+#
+#Assistant:"""
+]
+
+PARAMETERS = [
+{
+    "min_new_tokens": 0,
+    "max_new_tokens": 100,
+    "num_return_sequences": 1,
+    "do_sample": True,
+    "num_beams": 1,
+    "top_k": 50,
+    "top_p": 0.95,
+    "temperature": 1
+}
+]
 
 class Eagle:
     def __init__(self, model_name: str,  debug: bool = False, use_gpu: bool = False, cache_dir: Optional[str] = None) -> None:
@@ -18,16 +54,18 @@ class Eagle:
         self.model = AutoModelForCausalLM.from_pretrained(model_name, trust_remote_code=True, torch_dtype=torch.float16).to(self.device)
         self.logger = get_logger("models")
         
-    def query(self, instruction: str) -> str:
+    def query(self, instruction: str, MODEL_GENERATE_ARGS) -> str:
         try:
-            input = generate_chat_prompt(instruction)
-            encoded_input = self.tokenizer.encode(input, return_tensors="pt", truncation=True)
+            #input = generate_chat_prompt(instruction)
+            encoded_input = self.tokenizer.encode(instruction, return_tensors="pt", truncation=True)
             with torch.no_grad():
                 output = self.model.generate(encoded_input.to(self.device), **MODEL_GENERATE_ARGS)
             response = self.tokenizer.batch_decode(output, skip_special_tokens=True)[0]
             if self.debug:
-                self.logger.debug(f"############## Prompt ##############\n{input}")
+                self.logger.debug(f"############## Prompt ##############\n{MODEL_GENERATE_ARGS}\n{instruction}")
+                print(f"############## Prompt ##############\n{MODEL_GENERATE_ARGS}\n{instruction}")
                 self.logger.debug(f"############## Response ##############\n{response}")
+                print(f"############## Response ##############\n{response}")
             return response
         except Exception as e:
             self.logger.error(f"Exception during Eagle inference: {e}")
@@ -35,30 +73,25 @@ class Eagle:
 
 
     def paraphrase(self, text: str, language: str, iterations: int = 3):
-        instruction = f"Your goal is to paraphrase text in {LANGUAGE_CODE_MAP[language]} using different words and sentence composition. Responde with only paraphrased text and nothing else. Text to paraphrase:"
-        for _ in range(iterations):
-            prompt = f'{instruction} "{text}"'
-            text = self.query(prompt)
-        return text
+        for template in PROMPTS:
+            for config in PARAMETERS:
+                prompt = template.format(language=LANGUAGE_CODE_MAP[language], text=text)
+                #instruction = f"Your goal is to paraphrase text in {LANGUAGE_CODE_MAP[language]} using different words and sentence composition. Respond with only paraphrased text and nothing else. Text to paraphrase:"
+                for _ in range(iterations):
+                    #prompt = f'{instruction} "{text}"'
+                    answer = self.query(prompt, MODEL_GENERATE_ARGS=config)
+        return answer
         
         
     def similar_to_n(self, texts: List[str], language: str, k: int):
-        intro = f"You are a helpful assistant. Generate a short text similar to the following examples. The text must be in {LANGUAGE_CODE_MAP[language]} language.\n"
-        examples = ""
-        for idx, text in enumerate(texts[:k+1]):
-            examples += f"EXAMPLE {idx+1}: {text}\n"
-        examples += f"GENERATED TEXT: {texts[k+1]}\n\n"
-        
-        current = ""
-        for i, text in enumerate(texts[k+2:]):
-            current += f"EXAMPLE {i+1}: {text}\n"
-        current += "GENERATED TEXT:"
-        prompt = f"{intro}\n{examples}\n{current}"
-        return self.query(prompt)
+        #prompt = f"Instruction: Generate a short text similar to the following examples. The text must be in {LANGUAGE_CODE_MAP[language]} language.\n\nInput: {'\n'.join(texts)}\n\nResponse:"
+        joined = '\n'.join(texts)
+        prompt = f"{joined}\n"
+        return self.query(prompt, MODEL_GENERATE_ARGS=MODEL_GENERATE_ARGS)
 
     def keywords(self, keywords: List[str], language: str) -> str:
-        instruction = f"Generate sentense in {LANGUAGE_CODE_MAP[language]} containing the following words: {', '.join(keywords)}"
-        output = self.query(instruction)
+        instruction = f"Instruction: Generate sentense in {LANGUAGE_CODE_MAP[language]} containing the following words: {', '.join(keywords)}\n\nResponse:"
+        output = self.query(instruction, MODEL_GENERATE_ARGS=MODEL_GENERATE_ARGS)
         if len(output):
             output = output[len(generate_chat_prompt(instruction)):]
         return output.split('User:')[0]


### PR DESCRIPTION
I manually evaluated the quality of the generated texts on czech, slovak and english languages and tried to improve the methods with different prompts and model generation parameters.

Main findings:
- Paraphrasing seems to work in the Instruction:/Input:/Response: - It seems to have something to do with how the model was trained. (It sometimes includes this format even if it wasn't in the prompt)
- Paraphrasing using other prompts - the model often misunderstands the prompt
- Playing with different model generation parameters doesn't seem to do much - other than temperature - low temperature and the models starts to repeat itself often - higher temperature is better for more "diverse" answer
- For keywords method, again, using the Instruction:/Response: prompt template seems best
- Ending with "Response:" is best, the model less often continues in generating the instruction or other unwanted text
- With k_to_one, the model is often very confused from such complex instruction
- With k_to_one it seems its best to just provide the different social post examples in the prompt directly without any instruction and just let him continue generating
- I tried this "no instruction" approach also with paraphrasing but it sometimes generates gibberish like:
```
############## Prompt ##############
{'min_new_tokens': 0, 'max_new_tokens': 100, 'num_return_sequences': 1, 'do_sample': True, 'num_beams': 1, 'top_k': 50, 'top_p': 0.95, 'temperature': 1}
are gays allowed in budhism
cause ngl buddha sound kinda lit
Id fuck with him

############## Response ##############
are gays allowed in budhism
cause ngl buddha sound kinda lit
Id fuck with him
--- 897650105
>>897648948
--- 897650342
>>897648948
--- 897650420
>>897650269
--- 897650453
>>897648948
--- 897650522
>>897650355
--- 897650548
>>897648948
--- 897650575
>>897650453
nice
```
- This doesn't seem to happen when the text is longer (e.g. multiple posts in the k_to_one approach). The model seems to be more grounded and generates the correct format